### PR TITLE
Set max-width:100% for video elements

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -219,7 +219,7 @@ ol {
   margin: 10px 20px;
 }
 
-img {
+video, img {
   max-width: 100%;
 }
 


### PR DESCRIPTION
This fixes an issue where the video element is overflowing the text column width:

https://dhlab.yale.edu/projects/every-pixel/
